### PR TITLE
Pool truncation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,5 @@ env/
 data/
 
 .DS_Store
+
+.idea/

--- a/adaptvqe/pools.py
+++ b/adaptvqe/pools.py
@@ -2907,3 +2907,64 @@ class PairedDoubleCEO(CEO):
                         self.add_operator(q_operator_1 - q_operator_2, cnots=9, cnot_depth=7, lnn_cnots=25,
                                           parents=parents, source_orbs=source_orbs, target_orbs=target_orbs,
                                           ceo_type="diff")
+
+
+class OccupiedVirtualCEO(CEO):
+    """A CEO pool where all of the doubles are just excitations of the form
+    a^dagger_a a^dagger_b a_i a_j, where a and b are virtual orbitals and i and j
+    are occupied orbitals. This class assumes that the first n_occ-many orbitals
+    in the Hamiltonian (indices 0, ..., n_occ-1 in openfermion) are the occupied ones."""
+
+    def __init__(
+        self,
+        molecule = None,
+        sum = True,
+        diff = True,
+        dvg = False,
+        dve = False,
+        fermionic_swaps = False,
+        n = None,
+        source_ops = None,
+        n_occ: int = None
+    ):
+        self._n_occ = n_occ
+        super().__init__(molecule, sum, diff, dvg, dve, fermionic_swaps, n, source_ops)
+        assert self._n_occ <= self.n, f"n_occ must be smaller than {self.n}"
+
+    @property
+    def n_occ(self):
+        return self._n_occ
+
+    def create_doubles(self):
+        """
+        Create one-body CEOs.
+        """
+
+        for p in range(self._n_occ, self.n):
+
+            for q in range(p + 1, self.n):
+
+                for r in range(0, self._n_occ):
+
+                    for s in range(r + 1, self._n_occ):
+
+                        if (p + q + r + s) % 2 != 0:
+                            continue
+
+                        if self.track_parents:
+                            parents = self.parent_pool.get_ops_on_qubits([p, q, r, s])
+                        else:
+                            parents = None
+
+                        q_operators, orbs = create_excitations(p, q, r, s, fermionic=self.fermionic_swaps)
+
+                        for (q_operator_1, q_operator_2), (source_orbs, target_orbs) in zip(q_operators, orbs):
+
+                            if self.sum:
+                                self.add_operator(q_operator_1 + q_operator_2, cnots=9, cnot_depth=7, lnn_cnots=25,
+                                                  parents=parents, source_orbs=source_orbs, target_orbs=target_orbs,
+                                                  ceo_type="sum")
+                            if self.diff:
+                                self.add_operator(q_operator_1 - q_operator_2, cnots=9, cnot_depth=7, lnn_cnots=25,
+                                                  parents=parents, source_orbs=source_orbs, target_orbs=target_orbs,
+                                                  ceo_type="diff")

--- a/examples/Truncation/h2.py
+++ b/examples/Truncation/h2.py
@@ -1,0 +1,45 @@
+from adaptvqe.molecules import create_h2
+from adaptvqe.pools import CEO, PairedDoubleCEO
+from adaptvqe.algorithms.adapt_vqe import LinAlgAdapt
+
+r = 0.1
+mol = create_h2(r)
+
+ceo_pool = CEO(mol)
+paired_pool = PairedDoubleCEO(mol)
+
+print("CEO pool:")
+for op in ceo_pool.operators:
+    print(op.operator, "\n")
+print("paired CEO pool:")
+for op in paired_pool.operators:
+    print(op.operator, "\n")
+
+ceo_adapt = LinAlgAdapt(
+    pool=ceo_pool,
+    molecule=mol,
+    max_adapt_iter=1,
+    recycle_hessian=True,
+    tetris=True,
+    verbose=True,
+    threshold=0.1,
+)
+
+ceo_adapt.run()
+ceo_energy = ceo_adapt.energy
+
+paired_adapt = LinAlgAdapt(
+    pool=paired_pool,
+    molecule=mol,
+    max_adapt_iter=1,
+    recycle_hessian=True,
+    tetris=True,
+    verbose=True,
+    threshold=0.1,
+)
+
+paired_adapt.run()
+paired_energy = paired_adapt.energy
+
+err = abs(paired_energy - ceo_energy)
+print(f"Energy error: {err:5.4e}")

--- a/examples/Truncation/h2_ov.py
+++ b/examples/Truncation/h2_ov.py
@@ -1,0 +1,48 @@
+from adaptvqe.molecules import create_h2
+from adaptvqe.pools import CEO, PairedDoubleCEO, OccupiedVirtualCEO
+from adaptvqe.algorithms.adapt_vqe import LinAlgAdapt
+
+r = 0.1
+mol = create_h2(r)
+nelec = mol.n_electrons
+
+ceo_pool = CEO(mol)
+ov_pool = OccupiedVirtualCEO(mol, n_occ=nelec)
+
+print("CEO pool:")
+for op in ceo_pool.operators:
+    print(op.operator, "\n")
+print("OV CEO pool:")
+for op in ov_pool.operators:
+    print(op.operator, "\n")
+
+ceo_adapt = LinAlgAdapt(
+    pool=ceo_pool,
+    molecule=mol,
+    max_adapt_iter=1,
+    recycle_hessian=True,
+    tetris=True,
+    verbose=True,
+    threshold=0.1,
+)
+
+ceo_adapt.run()
+ceo_energy = ceo_adapt.energy
+
+ov_adapt = LinAlgAdapt(
+    pool=ov_pool,
+    molecule=mol,
+    max_adapt_iter=1,
+    recycle_hessian=True,
+    tetris=True,
+    verbose=True,
+    threshold=0.1,
+)
+
+ov_adapt.run()
+ov_energy = ov_adapt.energy
+
+err = abs(ov_energy - ceo_energy)
+print(f"Energy error: {err:5.4e}")
+fci_err = abs(mol.fci_energy - ov_energy)
+print(f"Error wrt FCI: {fci_err:5.4e}")

--- a/examples/Truncation/h5.py
+++ b/examples/Truncation/h5.py
@@ -1,0 +1,48 @@
+from adaptvqe.molecules import create_h5
+from adaptvqe.pools import CEO, PairedDoubleCEO
+from adaptvqe.algorithms.adapt_vqe import LinAlgAdapt
+
+r = 0.1
+mol = create_h5(r)
+
+ceo_pool = CEO(mol)
+paired_pool = PairedDoubleCEO(mol)
+
+print("CEO pool:")
+for op in ceo_pool.operators:
+    print(op.operator, "\n")
+print("paired CEO pool:")
+for op in paired_pool.operators:
+    print(op.operator, "\n")
+
+ceo_adapt = LinAlgAdapt(
+    pool=ceo_pool,
+    molecule=mol,
+    max_adapt_iter=10,
+    recycle_hessian=True,
+    tetris=True,
+    verbose=True,
+    threshold=0.1,
+)
+
+ceo_adapt.run()
+ceo_energy = ceo_adapt.energy
+
+paired_adapt = LinAlgAdapt(
+    pool=paired_pool,
+    molecule=mol,
+    max_adapt_iter=10,
+    recycle_hessian=True,
+    tetris=True,
+    verbose=True,
+    threshold=0.1,
+)
+
+paired_adapt.run()
+paired_energy = paired_adapt.energy
+
+print("Sizes of pools:")
+print(len(ceo_pool.operators), len(paired_pool.operators))
+
+err = abs(paired_energy - ceo_energy)
+print(f"Energy error: {err:5.4e}")

--- a/examples/Truncation/lih.py
+++ b/examples/Truncation/lih.py
@@ -1,0 +1,51 @@
+from adaptvqe.molecules import create_lih
+from adaptvqe.pools import CEO, PairedDoubleCEO
+from adaptvqe.algorithms.adapt_vqe import LinAlgAdapt
+
+r = 0.1
+mol = create_lih(r)
+
+ceo_pool = CEO(mol)
+paired_pool = PairedDoubleCEO(mol)
+
+print("CEO pool:")
+for op in ceo_pool.operators:
+    print(op.operator, "\n")
+print("paired CEO pool:")
+for op in paired_pool.operators:
+    print(op.operator, "\n")
+
+ceo_adapt = LinAlgAdapt(
+    pool=ceo_pool,
+    molecule=mol,
+    max_adapt_iter=10,
+    recycle_hessian=True,
+    tetris=True,
+    verbose=True,
+    threshold=0.1,
+)
+
+ceo_adapt.run()
+ceo_energy = ceo_adapt.energy
+
+paired_adapt = LinAlgAdapt(
+    pool=paired_pool,
+    molecule=mol,
+    max_adapt_iter=10,
+    recycle_hessian=True,
+    tetris=True,
+    verbose=True,
+    threshold=0.1,
+)
+
+paired_adapt.run()
+paired_energy = paired_adapt.energy
+
+print("Sizes of pools:")
+print(len(ceo_pool.operators), len(paired_pool.operators))
+
+err = abs(paired_energy - ceo_energy)
+print(f"CEO vs. paired CEO energy error: {err:5.4e}")
+
+exact_err = abs(mol.fci_energy - ceo_energy)
+print(f"Exact vs. CEO energy error: {exact_err:5.4e}")

--- a/examples/Truncation/pool_truncation.py
+++ b/examples/Truncation/pool_truncation.py
@@ -1,0 +1,8 @@
+from adaptvqe.utils import create_excitations
+
+p = 5
+q = 0
+r = 0
+s = 5
+operators, orbs = create_excitations(p, q, r, s, fermionic=True)
+print(operators)

--- a/examples/Truncation/pool_truncation.py
+++ b/examples/Truncation/pool_truncation.py
@@ -1,8 +1,0 @@
-from adaptvqe.utils import create_excitations
-
-p = 5
-q = 0
-r = 0
-s = 5
-operators, orbs = create_excitations(p, q, r, s, fermionic=True)
-print(operators)

--- a/examples/Truncation/water.py
+++ b/examples/Truncation/water.py
@@ -1,0 +1,57 @@
+from openfermion.chem import MolecularData, geometry_from_pubchem
+from openfermionpyscf import run_pyscf
+
+from adaptvqe.pools import CEO, PairedDoubleCEO
+from adaptvqe.algorithms.adapt_vqe import LinAlgAdapt
+
+geometry = geometry_from_pubchem("water")
+basis = 'sto-3g'
+multiplicity = 1
+charge = 0
+mol = MolecularData(geometry, basis, multiplicity, charge, description='BeH2')
+mol = run_pyscf(mol, run_fci=True, run_ccsd=True)
+
+ceo_pool = CEO(mol)
+paired_pool = PairedDoubleCEO(mol)
+
+print("CEO pool:")
+for op in ceo_pool.operators:
+    print(op.operator, "\n")
+print("paired CEO pool:")
+for op in paired_pool.operators:
+    print(op.operator, "\n")
+
+ceo_adapt = LinAlgAdapt(
+    pool=ceo_pool,
+    molecule=mol,
+    max_adapt_iter=10,
+    recycle_hessian=True,
+    tetris=True,
+    verbose=True,
+    threshold=0.1,
+)
+
+ceo_adapt.run()
+ceo_energy = ceo_adapt.energy
+
+paired_adapt = LinAlgAdapt(
+    pool=paired_pool,
+    molecule=mol,
+    max_adapt_iter=10,
+    recycle_hessian=True,
+    tetris=True,
+    verbose=True,
+    threshold=0.1,
+)
+
+paired_adapt.run()
+paired_energy = paired_adapt.energy
+
+print("Sizes of pools:")
+print(len(ceo_pool.operators), len(paired_pool.operators))
+
+err = abs(paired_energy - ceo_energy)
+print(f"CEO vs. paired CEO energy error: {err:5.4e}")
+
+exact_err = abs(mol.fci_energy - ceo_energy)
+print(f"Exact vs. CEO energy error: {exact_err:5.4e}")

--- a/examples/Truncation/water.py
+++ b/examples/Truncation/water.py
@@ -65,7 +65,7 @@ print("Sizes of pools:")
 print(len(ceo_pool.operators), len(paired_pool.operators))
 
 print("Times for regular CEO pool:")
-print(f"Building pool: {elapsed_time_ceo_pool:5.4e}\nRun: {elapsed_time_paired_adapt:5.4e}")
+print(f"Building pool: {elapsed_time_ceo_pool:5.4e}\nRun: {elapsed_time_ceo_adapt:5.4e}")
 print("Times for paired CEO pool:")
 print(f"Building pool: {elapsed_time_paired_pool:5.4e}\nRun: {elapsed_time_paired_adapt:5.4e}")
 

--- a/examples/Truncation/water_ov.py
+++ b/examples/Truncation/water_ov.py
@@ -1,0 +1,77 @@
+from time import perf_counter_ns
+
+from openfermion.chem import MolecularData, geometry_from_pubchem
+from openfermionpyscf import run_pyscf
+
+from adaptvqe.pools import CEO, PairedDoubleCEO, OccupiedVirtualCEO
+from adaptvqe.algorithms.adapt_vqe import LinAlgAdapt
+
+geometry = geometry_from_pubchem("water")
+basis = 'sto-3g'
+multiplicity = 1
+charge = 0
+mol = MolecularData(geometry, basis, multiplicity, charge, description='BeH2')
+mol = run_pyscf(mol, run_fci=True, run_ccsd=True)
+nelec = mol.n_electrons
+
+start_time = perf_counter_ns()
+ceo_pool = CEO(mol)
+end_time = perf_counter_ns()
+elapsed_time_ceo_pool = abs(end_time - start_time)
+
+start_time = perf_counter_ns()
+ov_pool = OccupiedVirtualCEO(mol, n_occ=nelec)
+end_time = perf_counter_ns()
+elapsed_time_ov_pool = abs(end_time - start_time)
+
+print("CEO pool:")
+for op in ceo_pool.operators:
+    print(op.operator, "\n")
+print("OV CEO pool:")
+for op in ov_pool.operators:
+    print(op.operator, "\n")
+
+start_time = perf_counter_ns()
+ceo_adapt = LinAlgAdapt(
+    pool=ceo_pool,
+    molecule=mol,
+    max_adapt_iter=1,
+    recycle_hessian=True,
+    tetris=True,
+    verbose=True,
+    threshold=0.1,
+)
+
+ceo_adapt.run()
+ceo_energy = ceo_adapt.energy
+end_time = perf_counter_ns()
+elapsed_time_ceo_adapt = abs(end_time - start_time)
+
+start_time = perf_counter_ns()
+ov_adapt = LinAlgAdapt(
+    pool=ov_pool,
+    molecule=mol,
+    max_adapt_iter=1,
+    recycle_hessian=True,
+    tetris=True,
+    verbose=True,
+    threshold=0.1,
+)
+
+ov_adapt.run()
+ov_energy = ov_adapt.energy
+end_time = perf_counter_ns()
+elapsed_time_ov_adapt = abs(end_time - start_time)
+
+print("Sizes of pools:")
+print(len(ceo_pool.operators), len(ov_pool.operators))
+
+print("Times for regular CEO pool:")
+print(f"Building pool: {elapsed_time_ceo_pool:5.4e}\nRun: {elapsed_time_ceo_adapt:5.4e}")
+print("Times for paired CEO pool:")
+print(f"Building pool: {elapsed_time_ov_pool:5.4e}\nRun: {elapsed_time_ov_adapt:5.4e}")
+
+err = abs(ov_energy - ceo_energy)
+print(f"Energy error: {err:5.4e}")
+fci_err = abs(mol.fci_energy - ov_energy)
+print(f"Error wrt FCI: {fci_err:5.4e}")


### PR DESCRIPTION
I tried created a CEO pool `OccupiedVirtualCEO` where all excitations are between occupied and virtual orbitals. For a water molecule, this pool produces the same energy as the regular CEO pool with a faster runtime and less operators. See `examples/truncation/water_ov.py` for an example.